### PR TITLE
removes % from cases per million

### DIFF
--- a/Covid19-Updates/Covid19-Updates/Modules/Dashboard/View/Cell/ViewModel/CovidDashboardCollectionHolderCellViewModel.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Dashboard/View/Cell/ViewModel/CovidDashboardCollectionHolderCellViewModel.swift
@@ -93,7 +93,7 @@ final class CovidDashboardCollectionHolderCellViewModel: DashboardCellCommonMode
                 return (title: row.localized(), value: value)
             case .deathsPerOneMilion:
                 if let value = covidData.deathsPerOneMillion {
-                    return (title: row.localized(), value: "\(value)%")
+                    return (title: row.localized(), value: "\(value)")
                 }
                 return (title: row.localized(), value: GeneralConstants.ReusableText.notAvailableString.localized())
             case .affectedCountry:


### PR DESCRIPTION
Fatalities per million were shown as ABC% . The percent sign was probably not needed ? 
<img width="160" alt="image" src="https://user-images.githubusercontent.com/10868280/80869163-61286900-8cbc-11ea-9899-50ca24ea19bf.png">
