### PR TITLE
Adds light mode support for the app

### DIFF
--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/AppGreen.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/AppGreen.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.058",
+          "green" : "0.568",
+          "red" : "0.238"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.358",
+          "green" : "0.868",
+          "red" : "0.538"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/AppRed.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/AppRed.colorset/Contents.json
@@ -5,9 +5,45 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.314",
-          "green" : "0.314",
-          "red" : "0.941"
+          "blue" : "0.214",
+          "green" : "0.214",
+          "red" : "0.841"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.114",
+          "green" : "0.164",
+          "red" : "0.791"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.464",
+          "green" : "0.464",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/Base.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/Base.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.466",
+          "green" : "0.568",
+          "red" : "0.003"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.766",
+          "green" : "0.868",
+          "red" : "0.303"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/Border.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/Border.colorset/Contents.json
@@ -11,6 +11,42 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.697",
+          "green" : "0.697",
+          "red" : "0.697"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.947",
+          "green" : "0.947",
+          "red" : "0.947"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/NavigationItem.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/NavigationItem.colorset/Contents.json
@@ -5,6 +5,24 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
+          "blue" : "0.421",
+          "green" : "0.283",
+          "red" : "0.150"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
           "blue" : "0.271",
           "green" : "0.133",
           "red" : "0.000"
@@ -23,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.723",
-          "green" : "0.356",
-          "red" : "0.000"
+          "blue" : "1.000",
+          "green" : "0.656",
+          "red" : "0.300"
         }
       },
       "idiom" : "universal"

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/SegmentBackground.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/SegmentBackground.colorset/Contents.json
@@ -5,6 +5,42 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
+          "blue" : "0.811",
+          "green" : "0.811",
+          "red" : "0.811"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.661",
+          "green" : "0.661",
+          "red" : "0.661"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
           "blue" : "0.961",
           "green" : "0.961",
           "red" : "0.961"

--- a/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/SubtitleText.colorset/Contents.json
+++ b/Covid19-Updates/Covid19-Updates/Assets.xcassets/AppColors/SubtitleText.colorset/Contents.json
@@ -5,9 +5,45 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.592",
-          "green" : "0.592",
-          "red" : "0.592"
+          "blue" : "0.442",
+          "green" : "0.442",
+          "red" : "0.442"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.292",
+          "green" : "0.292",
+          "red" : "0.292"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.742",
+          "green" : "0.742",
+          "red" : "0.742"
         }
       },
       "idiom" : "universal"

--- a/Covid19-Updates/Covid19-Updates/Modules/APIDoc/ViewController/CovidWebViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/APIDoc/ViewController/CovidWebViewController.swift
@@ -20,7 +20,7 @@ class CovidWebViewController: UIViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         viewModel = CovidWebViewModel()
         setupWebView()
         setupRefreshControl()

--- a/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidChartBaseViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidChartBaseViewController.swift
@@ -14,7 +14,7 @@ class CovidChartBaseViewController: UIViewController, ChartViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         edgesForExtendedLayout = []
     }
     

--- a/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidCountryTableViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidCountryTableViewController.swift
@@ -23,8 +23,8 @@ class CovidCountryTableViewController: UITableViewController {
         // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
         // self.navigationItem.rightBarButtonItem = self.editButtonItem
         isModalInPresentation = true
-        overrideUserInterfaceStyle = .dark
-        navigationController?.overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
+        navigationController?.overrideUserInterfaceStyle = .unspecified
         tableView.tableFooterView = UIView()
         tableView.estimatedRowHeight = 50.0
         tableView.rowHeight = UITableView.automaticDimension

--- a/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidPieChartViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Chart/ViewController/CovidPieChartViewController.swift
@@ -27,7 +27,7 @@ class CovidPieChartViewController: CovidChartBaseViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         
         bind(to: PieChartViewViewModel(with: CovidSharedData.shared.countryWiseCases))
         setup()

--- a/Covid19-Updates/Covid19-Updates/Modules/Dashboard/ViewController/CovidDashboardViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Dashboard/ViewController/CovidDashboardViewController.swift
@@ -159,7 +159,6 @@ extension CovidDashboardViewController: UITableViewDelegate, UITableViewDataSour
             return nil
         }
         headerView.titleLabel.text = viewModel?.headerText(at: section)
-        headerView.titleLabel.textColor = UIColor(appColor: .segmentBackground)
         return headerView
     }
     

--- a/Covid19-Updates/Covid19-Updates/Modules/Dashboard/ViewController/CovidDashboardViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Dashboard/ViewController/CovidDashboardViewController.swift
@@ -21,7 +21,7 @@ class CovidDashboardViewController: UIViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         
         bind(to: CovidDashboardViewModel())
         setupTableView()
@@ -62,7 +62,7 @@ class CovidDashboardViewController: UIViewController {
     }
     
     private func setupNavigationItem() {
-        tabBarController?.navigationController?.overrideUserInterfaceStyle = .dark
+        tabBarController?.navigationController?.overrideUserInterfaceStyle = .unspecified
         tabBarController?.navigationItem.largeTitleDisplayMode = .always
         tabBarController?.navigationController?.navigationBar.prefersLargeTitles = true
         let refreshNavigationItem = UIBarButtonItem(barButtonSystemItem: .refresh, target: self, action: #selector(onTapRefresh(_:)))
@@ -83,8 +83,8 @@ class CovidDashboardViewController: UIViewController {
                 subViewController.tabBarItem.title = viewModel?.indiaTrackerTabBarTitle
             }
         }
-        tabBarController?.navigationController?.overrideUserInterfaceStyle = .dark
-        tabBarController?.overrideUserInterfaceStyle = .dark
+        tabBarController?.navigationController?.overrideUserInterfaceStyle = .unspecified
+        tabBarController?.overrideUserInterfaceStyle = .unspecified
         tabBarController?.tabBar.tintColor = UIColor(appColor: .base)
     }
     

--- a/Covid19-Updates/Covid19-Updates/Modules/Details/ViewController/CovidDetailsViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Details/ViewController/CovidDetailsViewController.swift
@@ -19,8 +19,8 @@ class CovidDetailsViewController: UICollectionViewController {
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
-        overrideUserInterfaceStyle = .dark
-        navigationController?.overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
+        navigationController?.overrideUserInterfaceStyle = .unspecified
 
         title = viewModel?.countryName
 

--- a/Covid19-Updates/Covid19-Updates/Modules/IndiaUpdate/View/CovidIndiaStateCell.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/IndiaUpdate/View/CovidIndiaStateCell.swift
@@ -27,7 +27,6 @@ class CovidIndiaStateCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
-        uiSetup()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -37,25 +36,6 @@ class CovidIndiaStateCell: UITableViewCell {
     }
     
     // MARK: - UI Setup
-    private func uiSetup() {
-        locationNameLabel.textColor = .label
-        locationNameLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        confirmedCaseCountLabel.textColor = .systemPink
-        confirmedCaseCountLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        confirmedRecoveredCountLabel.textColor = UIColor(appColor: .green)
-        confirmedRecoveredCountLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        confirmedFatalityCountLabel.textColor = UIColor(appColor: .red)
-        confirmedFatalityCountLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        confirmedIndianCaseCountLabel.textColor = .systemOrange
-        confirmedIndianCaseCountLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        confirmedForeignerCaseCountLabel.textColor = .systemOrange
-        confirmedForeignerCaseCountLabel.font = UIFont.preferredFont(forTextStyle: .title1).bold()
-        caseCountTitleLabel.textColor = UIColor(appColor: .border)
-        recoveredCountTitleLabel.textColor = UIColor(appColor: .border)
-        fatalityTitleLabel.textColor = UIColor(appColor: .border)
-        indianCountTitleLabel.textColor = UIColor(appColor: .border)
-        foreignerCountTitleLabel.textColor = UIColor(appColor: .border)
-    }
 }
 
 // MARK: - Binding

--- a/Covid19-Updates/Covid19-Updates/Modules/IndiaUpdate/ViewController/CovidIndiaTrackerViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/IndiaUpdate/ViewController/CovidIndiaTrackerViewController.swift
@@ -23,7 +23,7 @@ class CovidIndiaTrackerViewController: UIViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         setupTableView()
         bind(to: CovidIndiaTrackerViewModel())
     }
@@ -39,7 +39,7 @@ class CovidIndiaTrackerViewController: UIViewController {
     
     // MARK: - Setup
     private func setupNavigationItem() {
-        tabBarController?.navigationController?.overrideUserInterfaceStyle = .dark
+        tabBarController?.navigationController?.overrideUserInterfaceStyle = .unspecified
         tabBarController?.navigationItem.largeTitleDisplayMode = .always
         let refreshNavigationItem = UIBarButtonItem(barButtonSystemItem: .refresh, target: self, action: #selector(onTapRefresh(_:)))
         refreshNavigationItem.tintColor = UIColor(appColor: .base)

--- a/Covid19-Updates/Covid19-Updates/Modules/Map/ViewController/CovidMapViewController.swift
+++ b/Covid19-Updates/Covid19-Updates/Modules/Map/ViewController/CovidMapViewController.swift
@@ -22,7 +22,7 @@ class CovidMapViewController: UIViewController {
         super.viewDidLoad()
         
         // Do any additional setup after loading the view.
-        overrideUserInterfaceStyle = .dark
+        overrideUserInterfaceStyle = .unspecified
         bind(to: CovidMapViewModel(with: CovidSharedData.shared.countryWiseCases))
         configureMap()
         registerAnnotationViewClasses()


### PR DESCRIPTION
**Changes:**
### Light and Dark Mode Colors
1. Added Lighter and Darker variants of existing base colors by adding new rgb values for base colours
1. Light color for dark mode= Base colour rgb values + 0.150
2. Dark color for light mode = Base colour rgb values - 0.150
3. At Places it was unable to achieve a + or - 0.150 for light or dark colors. In that case base color was shifted by that many points in multiple of 50 to make room for the color going out of bound and then the light and dark mode color were arrived at. 
---

### Disable overrideUserInterfaceStyle 

```overrideUserInterfaceStyle = .dark```  was replaced with ```overrideUserInterfaceStyle = .unspecified ```

----
### Others 
Some colors set via code was removed .

---
## UI :
![Kapture 2020-05-09 at 16 57 16](https://user-images.githubusercontent.com/10868280/81472515-28394880-9216-11ea-81c6-ba78b305b5a6.gif)

<img width="213" alt="image" src="https://user-images.githubusercontent.com/10868280/81472364-46eb0f80-9215-11ea-8d95-c4e67577b704.png"><img width="201" alt="image" src="https://user-images.githubusercontent.com/10868280/81472370-510d0e00-9215-11ea-80ca-3f062062a2ad.png">

<img width="210" alt="image" src="https://user-images.githubusercontent.com/10868280/81472424-a2b59880-9215-11ea-9677-150b0e662d92.png"><img width="207" alt="image" src="https://user-images.githubusercontent.com/10868280/81472416-97fb0380-9215-11ea-81b3-a2a3f0d57aec.png">
#6 
----



